### PR TITLE
[ENG-1024] Prevent false alarm from empty campaigns.

### DIFF
--- a/Command/HealthCommand.php
+++ b/Command/HealthCommand.php
@@ -32,12 +32,6 @@ class HealthCommand extends ModeratedCommand
     {
         $this->setName('mautic:health:check')
             ->setDescription('General all purpose health check.')
-            // ->addOption(
-            //     'campaign-rebuild-delay',
-            //     null,
-            //     InputOption::VALUE_OPTIONAL,
-            //     'The maximum number of contacts waiting to be ingested into a campaign from a segment.'
-            // )
             ->addOption(
                 'campaign-kickoff-delay',
                 null,

--- a/Model/HealthModel.php
+++ b/Model/HealthModel.php
@@ -175,7 +175,7 @@ class HealthModel
         if ($campaignId) {
             return isset($this->publishedCampaignsWithEvents[$campaignId]) ? $this->publishedCampaignsWithEvents[$campaignId] : null;
         } else {
-            return $this->publishedCampaigns;
+            return $this->publishedCampaignsWithEvents;
         }
     }
 

--- a/Model/HealthModel.php
+++ b/Model/HealthModel.php
@@ -15,6 +15,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Connections\MasterSlaveConnection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\ORM\EntityManager;
+use Mautic\CampaignBundle\Event\CampaignEvent;
 use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CampaignBundle\Model\EventModel;
 use Mautic\CoreBundle\Helper\CacheStorageHelper;
@@ -61,6 +62,9 @@ class HealthModel
     /** @var CacheStorageHelper */
     protected $cache;
 
+    /** @var array */
+    protected $publishedCampaignsWithEvents = [];
+
     /**
      * HealthModel constructor.
      *
@@ -100,7 +104,7 @@ class HealthModel
      */
     public function campaignKickoffCheck(OutputInterface $output = null)
     {
-        $campaignIds = array_keys($this->getPublishedCampaigns());
+        $campaignIds = array_keys($this->getPublishedCampaignsWithEvents());
         if (!$campaignIds) {
             return;
         }
@@ -137,6 +141,41 @@ class HealthModel
             ];
             $this->delays[] = $delay;
             $this->output($delay, $limit, $output);
+        }
+    }
+
+    /**
+     * @param null $campaignId
+     *
+     * @return array|bool
+     */
+    private function getPublishedCampaignsWithEvents($campaignId = null)
+    {
+        if (!$this->publishedCampaignsWithEvents) {
+            $campaignIds = array_keys($this->getPublishedCampaigns());
+            if ($campaignIds) {
+                /** @var CampaignEvent $event */
+                foreach ($this->eventModel->getRepository()->getEntities(
+                    [
+                        'filter' => [
+                            'force' => [
+                                [
+                                    'column' => 'IDENTITY(e.campaign)',
+                                    'expr'   => 'in',
+                                    'value'  => $campaignIds,
+                                ],
+                            ],
+                        ],
+                    ]
+                ) as $event) {
+                    $this->publishedCampaignsWithEvents[$event->getCampaign()->getId()] = $event->getCampaign()->getName();
+                }
+            }
+        }
+        if ($campaignId) {
+            return isset($this->publishedCampaignsWithEvents[$campaignId]) ? $this->publishedCampaignsWithEvents[$campaignId] : null;
+        } else {
+            return $this->publishedCampaigns;
         }
     }
 


### PR DESCRIPTION
**Please be sure you are submitting this against the _master_ branch.**

[//]: # This Pull Request (Place an 'X' for each):

| Risk Level                                | No | Low | High |
| ----------------------------------------- | -- | --- | ---- |
| Alters Lead Data?                         |  X  |     |      |
| Schema Change?                            |  X  |     |      |
| Adds A Query or Modifies Existing Query?  | X   |     |      |
| Adds or Modifies Existing Auto-Enhancer?  |  X  |     |      |
| Modifies Ingestion Process?               |  X  |     |      |
| Modifies sendContact Data?                |  X  |     |      |


[//]: # ( Required: )
#### Description:
Just prevents alerts when there's a delay for campaigns due to the fact that there are no events in the campaign, as that's expected behavior.